### PR TITLE
feat: add custom_component field for user-defined components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_text_popup"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bevy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_text_popup"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Easily create temporary text pop-up nodes in the Bevy game engine"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ And example showing custom pixel coordinates:
 
 `cargo run --example custom_locations`
 
+### Custom Components
+
+`cargo run --example custom_components`
+
 ### Modal
 
 `cargo run --example modal`

--- a/examples/custom_components.rs
+++ b/examples/custom_components.rs
@@ -1,0 +1,94 @@
+use bevy::prelude::*;
+use bevy_text_popup::{TextPopup, TextPopupEvent, TextPopupPlugin, TextPopupTimeout};
+
+#[derive(Component, Debug)]
+struct GamepadTipsRight;
+
+#[derive(Component, Debug)]
+struct PlayerOneUI;
+
+#[derive(Component, Debug)]
+struct NpcDialogue {
+    npc_id: u32,
+}
+
+#[derive(Component, Debug)]
+struct NotificationMessage;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, TextPopupPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (query_popups, cleanup_system))
+        .run();
+}
+
+fn setup(mut commands: Commands, mut text_popup_events: EventWriter<TextPopupEvent>) {
+    commands.spawn(Camera2d::default());
+
+    // Example 1: Gamepad tip with custom marker component
+    text_popup_events.send(TextPopupEvent {
+        content: "Press A to interact".to_string(),
+        timeout: TextPopupTimeout::Seconds(3),
+        custom_component: Some(|entity_commands| {
+            entity_commands.insert(GamepadTipsRight);
+        }),
+        ..default()
+    });
+
+    // Example 2: Player-specific UI popup with multiple components
+    text_popup_events.send(TextPopupEvent {
+        content: "Player 1 Health: 100%".to_string(),
+        timeout: TextPopupTimeout::Seconds(5),
+        custom_component: Some(|entity_commands| {
+            entity_commands.insert((PlayerOneUI, NotificationMessage));
+        }),
+        ..default()
+    });
+
+    // Example 3: NPC dialogue with custom data
+    text_popup_events.send(TextPopupEvent {
+        content: "Hello, traveler! Welcome to our village.".to_string(),
+        timeout: TextPopupTimeout::Frames(300),
+        custom_component: Some(|entity_commands| {
+            entity_commands.insert(NpcDialogue { npc_id: 42 });
+        }),
+        ..default()
+    });
+}
+
+fn query_popups(
+    gamepad_tips: Query<Entity, (With<TextPopup>, With<GamepadTipsRight>)>,
+    player_ui: Query<Entity, (With<TextPopup>, With<PlayerOneUI>)>,
+    npc_dialogues: Query<&NpcDialogue, With<TextPopup>>,
+) {
+    // Query for gamepad tips
+    for entity in gamepad_tips.iter() {
+        info!("Found gamepad tip popup: {:?}", entity);
+    }
+
+    // Query for player-specific UI
+    for entity in player_ui.iter() {
+        info!("Found Player 1 UI popup: {:?}", entity);
+    }
+
+    // Query for NPC dialogues with data
+    for npc_dialogue in npc_dialogues.iter() {
+        info!("Found NPC dialogue from NPC ID: {}", npc_dialogue.npc_id);
+    }
+}
+
+fn cleanup_system(
+    mut commands: Commands,
+    query: Query<Entity, (With<TextPopup>, With<NpcDialogue>)>,
+    mut iterations: Local<usize>,
+) {
+    *iterations += 1;
+    // Demonstrate custom cleanup logic for NPC dialogues after 4 seconds
+    if *iterations > 240 {
+        for entity in query.iter() {
+            info!("Custom cleanup: Removing NPC dialogue popup: {:?}", entity);
+            commands.entity(entity).despawn_recursive();
+        }
+    }
+}

--- a/examples/custom_components.rs
+++ b/examples/custom_components.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
-use bevy_text_popup::{TextPopup, TextPopupEvent, TextPopupPlugin, TextPopupTimeout};
+use bevy_text_popup::{
+    TextPopup, TextPopupEvent, TextPopupLocation, TextPopupPlugin, TextPopupTimeout,
+};
 
 #[derive(Component, Debug)]
 struct GamepadTipsRight;
@@ -27,9 +29,10 @@ fn setup(mut commands: Commands, mut text_popup_events: EventWriter<TextPopupEve
     commands.spawn(Camera2d::default());
 
     // Example 1: Gamepad tip with custom marker component
-    text_popup_events.send(TextPopupEvent {
+    text_popup_events.write(TextPopupEvent {
         content: "Press A to interact".to_string(),
         timeout: TextPopupTimeout::Seconds(3),
+        location: TextPopupLocation::Top,
         custom_component: Some(|entity_commands| {
             entity_commands.insert(GamepadTipsRight);
         }),
@@ -37,7 +40,7 @@ fn setup(mut commands: Commands, mut text_popup_events: EventWriter<TextPopupEve
     });
 
     // Example 2: Player-specific UI popup with multiple components
-    text_popup_events.send(TextPopupEvent {
+    text_popup_events.write(TextPopupEvent {
         content: "Player 1 Health: 100%".to_string(),
         timeout: TextPopupTimeout::Seconds(5),
         custom_component: Some(|entity_commands| {
@@ -47,9 +50,10 @@ fn setup(mut commands: Commands, mut text_popup_events: EventWriter<TextPopupEve
     });
 
     // Example 3: NPC dialogue with custom data
-    text_popup_events.send(TextPopupEvent {
+    text_popup_events.write(TextPopupEvent {
         content: "Hello, traveler! Welcome to our village.".to_string(),
         timeout: TextPopupTimeout::Frames(300),
+        location: TextPopupLocation::Bottom,
         custom_component: Some(|entity_commands| {
             entity_commands.insert(NpcDialogue { npc_id: 42 });
         }),
@@ -88,7 +92,7 @@ fn cleanup_system(
     if *iterations > 240 {
         for entity in query.iter() {
             info!("Custom cleanup: Removing NPC dialogue popup: {:?}", entity);
-            commands.entity(entity).despawn_recursive();
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     prelude::{
-        default, Alpha, App, Color, Commands, Component, Entity, Event, Name, Node, Plugin, Text,
+        default, Alpha, App, Color, Commands, Component, Entity, EntityCommands, Event, Name, Node, Plugin, Text,
         Update,
     },
     text::{JustifyText, TextColor, TextFont, TextLayout},
@@ -67,6 +67,9 @@ pub struct TextPopupEvent {
     pub z_index: GlobalZIndex,
     pub timeout: TextPopupTimeout,
     pub name: Option<Name>,
+    /// Optional function to add custom components to the popup entity.
+    /// The function receives mutable access to the EntityCommands for the root popup entity.
+    pub custom_component: Option<fn(&mut EntityCommands)>,
 }
 
 impl Default for TextPopupEvent {
@@ -91,6 +94,7 @@ impl Default for TextPopupEvent {
             z_index: GlobalZIndex(i32::MAX),
             timeout: TextPopupTimeout::Never,
             name: None,
+            custom_component: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 
 use bevy::{
     prelude::{
-        default, Alpha, App, Color, Commands, Component, Entity, EntityCommands, Event, Name, Node, Plugin, Text,
-        Update,
+        default, Alpha, App, Color, Commands, Component, Entity, EntityCommands, Event, Name, Node,
+        Plugin, Text, Update,
     },
     text::{JustifyText, TextColor, TextFont, TextLayout},
     ui::{BackgroundColor, BorderColor, GlobalZIndex, UiRect, Val},

--- a/src/text_popup.rs
+++ b/src/text_popup.rs
@@ -136,7 +136,7 @@ fn spawn_text_popup(
         spawned_root.insert(name.clone());
     }
     if let Some(custom_component_fn) = text_popup_event.custom_component {
-        custom_component_fn(&mut spawned_root);
+        custom_component_fn(spawned_root);
     }
     let root_id = spawned_root.id();
     spawned_root.with_children(|commands| {

--- a/src/text_popup.rs
+++ b/src/text_popup.rs
@@ -135,6 +135,9 @@ fn spawn_text_popup(
     if let Some(name) = &text_popup_event.name {
         spawned_root.insert(name.clone());
     }
+    if let Some(custom_component_fn) = text_popup_event.custom_component {
+        custom_component_fn(&mut spawned_root);
+    }
     let root_id = spawned_root.id();
     spawned_root.with_children(|commands| {
         commands


### PR DESCRIPTION
Adds a new `custom_component` field to `TextPopupEvent` that allows users to provide a function for adding custom components to popup entities.

This enables:
- Multiple marker components for different popup types (NPC dialogues, notifications, etc.)
- Custom data components for complex game scenarios
- Better querying performance compared to Name-based workarounds
- Fine-grained control over popup entity composition

Resolves #10

Generated with [Claude Code](https://claude.ai/code)